### PR TITLE
build(deps): phase 3 — bump codecov-action v6 and upload-artifact v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/coverage-final.json
@@ -127,7 +127,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: nextjs-build
           path: .next/


### PR DESCRIPTION
## Summary

Consolidates the two GitHub Actions major-version bumps into one PR. CI itself validates these (no local verification possible for workflow changes).

### Bumps
- `codecov/codecov-action` v5 → v6 (#112) — requires node24; `ubuntu-latest` provides it
- `actions/upload-artifact` v6 → v7 (#104) — ESM upgrade, adds optional `archive` param (unused here); our `name`/`path`/`retention-days` inputs are unchanged

Closes #112, #104.

## Test plan

- [ ] CI coverage job uploads to Codecov successfully
- [ ] CI build job uploads `nextjs-build` artifact successfully
- [ ] All existing jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)