### PR TITLE
ci: group dependabot PRs so patch/minor bumps batch weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,32 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# See https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+#
+# Grouping strategy: patch/minor bumps batch together so CI runs once per week
+# per ecosystem instead of once per package. Majors still come through as
+# individual PRs because they're more likely to need manual review.
 
 version: 2
 updates:
-  - package-ecosystem: 'npm' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      production-minor-patch:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
+      development-minor-patch:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      actions-all:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary

Prevents the situation we just had — 15 separate dependabot PRs in one month, each one a lockfile diff that needed individual merges.

### Grouping
- **npm: production** — patch/minor bumps batched into one PR per week
- **npm: development** — patch/minor bumps batched into one PR per week
- **github-actions** — all bumps (including majors) batched into one PR per week

### What stays ungrouped
- npm **major** bumps — still come through as individual PRs. Majors are more likely to have breaking changes, and a bad one in a group blocks everything else in that group.

## Test plan

- [ ] After merge, wait for next weekly dependabot run — expect one grouped PR per ecosystem instead of one per package
- [ ] Verify grouped PR title includes all bumped packages (e.g. `bump the production-minor-patch group with N updates`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)