### PR TITLE
chore(release): bump version to 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wsg-check",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wsg-check",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ark-ui/react": "^5.34.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsg-check",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Checks a website with the Web Sustainability Guidelines (W3C WSG)",
   "license": "Apache-2.0",
   "author": "Ivan Storck",

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,4 +1,5 @@
 import type { WSGCheckConfig } from './types'
+import { VERSION } from '../version'
 
 /**
  * Sensible default configuration values for wsg-check.
@@ -12,7 +13,7 @@ export const DEFAULT_CONFIG: Omit<WSGCheckConfig, 'url'> = {
 
   timeout: 30_000, // 30 seconds
   maxDepth: 1, // single page by default
-  userAgent: 'Mozilla/5.0 (compatible; wsg-check/0.0.1; +https://github.com/ivanoats/wsg-check)',
+  userAgent: `Mozilla/5.0 (compatible; wsg-check/${VERSION}; +https://github.com/ivanoats/wsg-check)`,
   followRedirects: true,
 
   format: 'terminal',

--- a/src/utils/http-client.ts
+++ b/src/utils/http-client.ts
@@ -12,6 +12,7 @@ import axios, { AxiosError, type AxiosInstance, type AxiosResponse } from 'axios
 import robotsParser from 'robots-parser'
 import { FetchError, type Result, ok, err } from './errors'
 import { isDisallowedHost, dnsResolvesToPrivateAddress } from './ssrf'
+import { VERSION } from '../version'
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -65,7 +66,7 @@ export interface HttpClientOptions {
 
 const DEFAULT_OPTIONS: Required<HttpClientOptions> = {
   timeout: 30_000,
-  userAgent: 'Mozilla/5.0 (compatible; wsg-check/0.0.1; +https://github.com/ivanoats/wsg-check)',
+  userAgent: `Mozilla/5.0 (compatible; wsg-check/${VERSION}; +https://github.com/ivanoats/wsg-check)`,
   followRedirects: true,
   maxRetries: 2,
   retryDelay: 500,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,9 @@
+/**
+ * Package version — single source of truth.
+ *
+ * tsup/esbuild resolves this import at build time so the version string in
+ * every published bundle always matches the `version` field in package.json.
+ */
+import pkg from '../package.json'
+
+export const VERSION = pkg.version


### PR DESCRIPTION
## Summary

First public release to npm. After this merges, a GitHub release on tag `v0.1.0` will trigger `.github/workflows/publish.yml`, which runs `npm publish --provenance --access public`.

### What changes
- `package.json` → `0.0.1` → `0.1.0`
- `package-lock.json` root version fields updated

### After merge (next step)
```
gh release create v0.1.0 --title "v0.1.0" --generate-notes
```

`NPM_TOKEN` secret is configured. `npm run build:cli` verified locally (157 KB bundle, `--version` reports correct version).

## Test plan

- [x] Local build: `npm run build:cli` → clean
- [x] Local CLI smoke test: `node dist/cli/index.js --version` → `0.1.0`
- [ ] CI green on this PR
- [ ] After merge + release: publish workflow runs and `npm view wsg-check` returns 0.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)