### PR TITLE
chore(release): scope to @sustainablewebsites/wsg-check, bump to 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ A Web Sustainability Guidelines checker for websites. It checks a website agains
 
 ```bash
 # Check a website from the command line (no install needed)
-npx wsg-check https://example.com
+npx @sustainablewebsites/wsg-check https://example.com
 
 # Or install globally
-npm install -g wsg-check
+npm install -g @sustainablewebsites/wsg-check
 wsg-check https://example.com --format json --output report.json
 ```
 
@@ -912,16 +912,16 @@ WSG-Check ships with a command-line tool that lets you check any website directl
 
 ```bash
 # Check a website with default (terminal) output
-npx wsg-check https://example.com
+npx @sustainablewebsites/wsg-check https://example.com
 
 # Output as JSON
-npx wsg-check https://example.com --format json
+npx @sustainablewebsites/wsg-check https://example.com --format json
 
 # Save the report to a file
-npx wsg-check https://example.com --format markdown --output report.md
+npx @sustainablewebsites/wsg-check https://example.com --format markdown --output report.md
 
 # Fail the process (exit 1) if the score is below 70
-npx wsg-check https://example.com --fail-threshold 70
+npx @sustainablewebsites/wsg-check https://example.com --fail-threshold 70
 ```
 
 ### Options
@@ -945,7 +945,7 @@ Use `--fail-threshold` to fail your pipeline when a site's sustainability score 
 ```yaml
 # .github/workflows/sustainability.yml
 - name: Check sustainability
-  run: npx wsg-check https://example.com --fail-threshold 60 --format json --output wsg-report.json
+  run: npx @sustainablewebsites/wsg-check https://example.com --fail-threshold 60 --format json --output wsg-report.json
 - name: Upload report
   uses: actions/upload-artifact@v4
   with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "wsg-check",
-  "version": "0.1.0",
+  "name": "@sustainablewebsites/wsg-check",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wsg-check",
-      "version": "0.1.0",
+      "name": "@sustainablewebsites/wsg-check",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ark-ui/react": "^5.34.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "wsg-check",
-  "version": "0.1.0",
+  "name": "@sustainablewebsites/wsg-check",
+  "version": "0.1.1",
   "description": "Checks a website with the Web Sustainability Guidelines (W3C WSG)",
   "license": "Apache-2.0",
   "author": "Ivan Storck",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@sustainablewebsites/wsg-check",
   "version": "0.1.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Checks a website with the Web Sustainability Guidelines (W3C WSG)",
   "license": "Apache-2.0",
   "author": "Ivan Storck",


### PR DESCRIPTION
## Summary

Scopes the package under the `@sustainablewebsites` org on npm. Unscoped `wsg-check` was rejected by npm's name-similarity filter (too close to existing `es-check`).

### Changes
- `package.json` name → `@sustainablewebsites/wsg-check`
- version → `0.1.0` → `0.1.1` (v0.1.0 tag already exists from the earlier failed publish)
- README install examples and `npx` usage updated to scoped name
- Lockfile name field updated

### Unchanged
- **CLI binary is still `wsg-check`** — `bin` field in package.json maps `wsg-check` → `./dist/cli/index.js` regardless of the scoped package name. Users still run `wsg-check https://...` after install.
- Publish workflow (`publish.yml`) — same. Trusted Publishing (once configured on npm) works identically for scoped names.

### Before merging
Ivan needs to decide on the publish-auth path:
1. Configure Trusted Publishing for `@sustainablewebsites/wsg-check` at https://www.npmjs.com/settings/sustainablewebsites/trusted-publishers (if npm UI allows pre-registering unpublished names) → I'll open a follow-up dropping `NODE_AUTH_TOKEN` from `publish.yml`
2. Or: keep the Automation token for the first publish, then migrate to Trusted Publishing once the package exists

Either way, merge this, cut `v0.1.1`, and the publish should succeed.

## Test plan

- [x] `npm run type-check` — passes
- [x] `npm run test:run` — 967/967 tests
- [ ] CI green on this PR
- [ ] After merge + release v0.1.1: `npm view @sustainablewebsites/wsg-check` returns 0.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)