### PR TITLE
ci: publish to npm via Trusted Publishing (OIDC), drop NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,5 +28,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Finalizes the migration to npm Trusted Publishing. The `@sustainablewebsites/wsg-check` package has a trusted publisher registered on npmjs.com bound to this repository and this workflow file, so `npm publish` authenticates via GitHub Actions OIDC using the `id-token: write` permission already present in the workflow.

### Change
```yaml
- name: Publish to npm
  run: npm publish --provenance --access public
- env:
-   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

### After merge

Delete the no-longer-needed secret:
```
gh secret delete NPM_TOKEN
```

No long-lived npm credential will exist on disk or in the repo — every publish is signed by GitHub's OIDC identity and tied to the exact workflow run that built the tarball.

### Verification path

Next release (e.g. `v0.1.2` when it comes) will confirm OIDC works end-to-end. If it fails, the `NODE_AUTH_TOKEN` reinstatement is a one-line revert.

## Test plan

- [ ] CI green on this PR
- [ ] After merge + next release tag: publish succeeds without `NPM_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)