### PR TITLE
chore(release): bump version to 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sustainablewebsites/wsg-check",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sustainablewebsites/wsg-check",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ark-ui/react": "^5.36.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sustainablewebsites/wsg-check",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

Patch release bundling dependency updates merged since v0.1.1. First release to exercise Trusted Publishing (OIDC) end-to-end — no `NPM_TOKEN` secret involved.

### Shipped updates
| PR | Bump |
|---|---|
| #129 | production minor/patch group (6 packages) |
| #136 | development minor/patch group (9 packages) |
| #132 | `rate-limiter-flexible` 9.1.1 → 11.0.1 |
| #133 | `typescript` 5.9.3 → 6.0.3 (dev) |
| #134 | `@vitejs/plugin-react` 5.1.4 → 6.0.1 (dev) |

### After merge

```
gh release create v0.1.2 --title "v0.1.2" --generate-notes
```

If OIDC publish succeeds, Trusted Publishing is fully validated. If it fails, reverting PR #138 restores token auth as a fallback.

## Test plan

- [x] `npm run type-check` — passes
- [x] `npm run test:run` — 967/967 tests
- [x] `npm run build:cli` — 159.87 KB bundle; `node dist/cli/index.js --version` → `0.1.2`
- [ ] CI green on this PR
- [ ] After merge + release v0.1.2: OIDC publish succeeds, `npm view @sustainablewebsites/wsg-check` returns 0.1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)