### PR TITLE
ci: bump publish workflow to Node 24 (needed for OIDC trusted publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,10 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Setup npm for Trusted Publishing
+        run: |
+          npm install --global npm@^11.5.1
+          npm --version
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          # Node 24 ships with npm 11.x, required for Trusted Publishing (OIDC)
+          # token exchange with the npm registry (added in npm 11.5.1).
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,10 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  # Allows manual dispatch from the Actions tab after release-please
+  # merges a release PR — GITHUB_TOKEN-created releases don't trigger
+  # other workflows, so this is how we publish them.
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary

Two changes to `publish.yml`:

1. **Node 22 → 24** — npm 11.5.1+ is required for Trusted Publishing's OIDC → npm-token exchange. Node 22 ships with npm 10.x; Node 24 ships with npm 11.x.
2. **Add `workflow_dispatch:` trigger** — release-please creates releases via `GITHUB_TOKEN`, which per GitHub's anti-loop policy doesn't fire subsequent workflows. Manual dispatch from the Actions tab is how we'll publish release-please-created releases.

### Why Node 24 is needed (the v0.1.2 failure)

- Sigstore provenance signed successfully (logIndex 1355869797) — so OIDC token generation works
- Registry PUT returned 404 Not Found — the npm CLI couldn't exchange the OIDC token for a publish token, because that exchange path only exists in npm 11.5.1+

### After merge — retry v0.1.2

```
gh run rerun 24759292297
```

Reuses the v0.1.2 release event. If OIDC now works, the package publishes.

### After release-please (#141) is active

1. release-please opens a Release PR
2. You merge it — it tags + creates a GitHub release
3. You click "Run workflow" on `publish.yml` in the Actions tab, pick `main`, confirm — OIDC publish fires

## Test plan

- [ ] CI validates YAML changes
- [ ] After merge: OIDC publish of v0.1.2 (via rerun) or next release succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)